### PR TITLE
Fix typo in key name, `s/usename/usenames/`

### DIFF
--- a/xcolor.dtx
+++ b/xcolor.dtx
@@ -4119,7 +4119,7 @@
  {
    ,usenames   .code    =
      {\PackageWarning{xcolor}{Package option `usenames' is obsolete and ignored}}
-   ,usename    .usage   = preamble
+   ,usenames   .usage   = preamble
    ,hyperref   .code    =
      {\PackageWarning{xcolor}{Package option `hyperref' is obsolete and ignored}}
    ,hyperref   .usage   = preamble


### PR DESCRIPTION
This was pointed out by @mrpiggi in comment https://github.com/latex3/xcolor/commit/c74a17bfb178092afb3bd2bcdfbd0ddf474f2221#r132642683.